### PR TITLE
fix(i18n): 国际化问题

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -39,7 +39,7 @@ class Module extends BaseModule
             'sourceLanguage' => $this->sourceLanguage,
             'basePath' => '@graychen/yii2/queue/backend/messages',
             'fileMap' => [
-                'graychen/yii2/queue/backend/message' => 'queue.php',
+                'graychen/yii2/queue/backend/queue' => 'queue.php',
             ],
         ];
     }

--- a/src/messages/zh-CN/queue.php
+++ b/src/messages/zh-CN/queue.php
@@ -1,5 +1,12 @@
 <?php
 
 return [
-    'execution_time' => '执行时间'
+    'Queue ID' => '队列ID',
+    'Catalog' => '类别',
+    'Name' => '任务名称',
+    'Description' => '任务详情',
+    'Exec Time' => '执行时间',
+    'Status' => '状态',
+    'Created At' => '创建时间',
+    'Updated At' => '更新时间'
 ];

--- a/src/messages/zh-TW/queue.php
+++ b/src/messages/zh-TW/queue.php
@@ -1,5 +1,12 @@
 <?php
 
 return [
-    'execution_time' => '執行時間'
+    'Queue ID' => '隊列ID',
+    'Catalog' => '類別',
+    'Name' => '任務名稱',
+    'Description' => '任務詳情',
+    'Exec Time' => '執行時間',
+    'Status' => '狀態',
+    'Created At' => '創建時間',
+    'Updated At' => '更新時間'
 ];

--- a/src/models/Queue.php
+++ b/src/models/Queue.php
@@ -1,6 +1,8 @@
 <?php
+
 namespace graychen\yii2\queue\backend\models;
 
+use graychen\yii2\queue\backend\Module;
 use Yii;
 use yii\behaviors\TimestampBehavior;
 use yii\db\ActiveRecord;
@@ -43,32 +45,31 @@ class Queue extends ActiveRecord
     public function attributeLabels()
     {
         return [
-            'id' => Yii::t('app/queue', 'ID'),
-            'queue_id' => Yii::t('app/queue', '队列id'),
-            'catalog' => Yii::t('app/queue', '类别'),
-            'name' => Yii::t('app/queue', '任务名称'),
-            'description' => Yii::t('app/queue', '详请信息'),
-            'exec_time' => Yii::t('app/queue', '执行时间'),
-            'status' => Yii::t('app/queue', '状态'),
-            'created_at' => Yii::t('app/queue', '队列创建时间'),
-            'updated_at' => Yii::t('app/queue', '队列修改时间'),
-            'execution_time' => Yii::t('app/queue', '队列执行时间')
+            'id' => Module::t('queue', 'ID'),
+            'queue_id' => Module::t('queue', 'Queue ID'),
+            'catalog' => Module::t('queue', 'Catalog'),
+            'name' => Module::t('queue', 'Name'),
+            'description' => Module::t('queue', 'Description'),
+            'exec_time' => Module::t('queue', 'Exec Time'),
+            'status' => Module::t('queue', 'Status'),
+            'created_at' => Module::t('queue', 'Created At'),
+            'updated_at' => Module::t('queue', 'Updated At'),
         ];
     }
 
     public function getExecutionTime()
     {
-        return $this->exec_time+$this->created_at;
+        return $this->exec_time + $this->created_at;
     }
 
     public function getStatus($id)
     {
         if (Yii::$app->queue->isWaiting($id) || Yii::$app->queue->isReserved($id)) {
-            $status=0;
+            $status = 0;
         } elseif (Yii::$app->queue->isDone($id)) {
-            $status=1;
+            $status = 1;
         } else {
-            $status=-1;
+            $status = -1;
         }
         return $status;
     }

--- a/src/views/default/index.php
+++ b/src/views/default/index.php
@@ -97,7 +97,7 @@ $this->params['breadcrumbs'][] = $this->title;
                 }
             ],
             [
-                'attribute' => 'execution_time',
+                'attribute' => 'exec_time',
                 'value' => function ($model) {
                     return date("Y-m-d H:i:s", $model->exec_time);
                 }

--- a/src/views/default/view.php
+++ b/src/views/default/view.php
@@ -44,7 +44,7 @@ $this->params['breadcrumbs'][] = $this->title;
                     }
                 ],
                 [
-                    'attribute' => 'execution_time',
+                    'attribute' => 'exec_time',
                     'value' => function ($model) {
                         return date("Y-m-d H:i:s", $model->exec_time);
                     }

--- a/tests/models/QueueTest.php
+++ b/tests/models/QueueTest.php
@@ -47,7 +47,6 @@ class QueueTest extends TestCase
         $this->assertArrayHasKey('status', $labels);
         $this->assertArrayHasKey('created_at', $labels);
         $this->assertArrayHasKey('updated_at', $labels);
-        $this->assertArrayHasKey('execution_time', $labels);
     }
 
     public function testGetExecutionTime()


### PR DESCRIPTION
1. 不支持国际化
2. app中如果不配置 app/* 的 i18n/translations, 会报错